### PR TITLE
Update distributed-queries.po

### DIFF
--- a/locale/zh/LC_MESSAGES/core/distributed-queries.po
+++ b/locale/zh/LC_MESSAGES/core/distributed-queries.po
@@ -85,7 +85,7 @@ msgstr ""
 # 058bc9452899413caa77aab38c8d8574
 #: ../source/core/distributed-queries.txt:51
 msgid "Read Operations to Replica Sets"
-msgstr "复制集上的写操作"
+msgstr "复制集上的读操作"
 
 # 7b2b1aeff65e4d4ebc8cecb7020006d5
 #: ../source/core/distributed-queries.txt:53


### PR DESCRIPTION
因该是“读”而不是“写”